### PR TITLE
Update SDL to stable 2.30.0 release

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
 		FetchContent_Declare(
 			SDL2
 			GIT_REPOSITORY https://github.com/libsdl-org/SDL
-			GIT_TAG release-2.28.5
+			GIT_TAG release-2.30.0
 			GIT_PROGRESS TRUE
 		)
 		FetchContent_MakeAvailable(SDL2)


### PR DESCRIPTION
Update SDL to stable 2.30.0 release (https://github.com/libsdl-org/SDL/releases/tag/release-2.30.0)