### PR TITLE
Use relative mouse API

### DIFF
--- a/Platform/src/foster_platform.c
+++ b/Platform/src/foster_platform.c
@@ -167,10 +167,9 @@ void FosterPollEvents()
 
 	// always update the mouse position state
 	{
-		int win_x, win_y, x, y;
-		SDL_GetWindowPosition(fstate.window, &win_x, &win_y);
-		SDL_GetGlobalMouseState(&x, &y);
-		fstate.desc.onMouseMove((float)(x - win_x), (float)(y - win_y));
+		int rel_x, rel_y;
+		SDL_GetMouseState(&rel_x, &rel_y);
+		fstate.desc.onMouseMove((float)(rel_x), (float)(rel_y));
 	}
 
 	SDL_Event event;


### PR DESCRIPTION
On some platforms `SDL_GetWindowPosition` will always return 0,0 while mouse position is still absolute. This would result in an absolute position inside `Input.Mouse.Position` instead of a relative one.
This PR lets SDL handle the relative positioning.