### PR TITLE
Include the mouse delta as part of the input state

### DIFF
--- a/Framework/Input/Input.cs
+++ b/Framework/Input/Input.cs
@@ -203,6 +203,8 @@ public static class Input
 				var pixels = new Point2(App.WidthInPixels, App.HeightInPixels);
 				nextState.Mouse.Position.X = (ev.Mouse.X / size.X) * pixels.X;
 				nextState.Mouse.Position.Y = (ev.Mouse.Y / size.Y) * pixels.Y;
+				nextState.Mouse.Delta.X = ev.Mouse.deltaX;
+				nextState.Mouse.Delta.Y = ev.Mouse.deltaY;
 				break;
 			}
 			case Platform.FosterEventType.MouseWheel:

--- a/Framework/Input/Mouse.cs
+++ b/Framework/Input/Mouse.cs
@@ -21,6 +21,11 @@ public class Mouse
 	/// </summary>
 	public Vector2 Position;
 
+	/// <summary>
+	/// Delta to the previous mouse position, in Pixel Coordinates.
+	/// </summary>
+	public Vector2 Delta;
+
 	public float X
 	{
 		get => Position.X;
@@ -70,6 +75,7 @@ public class Mouse
 		Array.Copy(other.timestamp, 0, timestamp, 0, MaxButtons);
 
 		Position = other.Position;
+		Delta = other.Delta;
 		wheelValue = other.wheelValue;
 	}
 

--- a/Framework/Platform.cs
+++ b/Framework/Platform.cs
@@ -67,6 +67,8 @@ internal static class Platform
 			public FosterEventType EventType;
 			public float X;
 			public float Y;
+			public float deltaX;
+			public float deltaY;
 			public int Button;
 			public byte ButtonPressed;
 		}

--- a/Platform/include/foster_platform.h
+++ b/Platform/include/foster_platform.h
@@ -477,6 +477,8 @@ typedef union FosterEvent
 		int eventType;
 		float x;
 		float y;
+		float deltaX;
+		float deltaY;
 		int button;
 		FosterBool buttonPressed;
 	} mouse;

--- a/Platform/src/foster_platform.c
+++ b/Platform/src/foster_platform.c
@@ -171,11 +171,17 @@ FosterBool FosterPollEvents(FosterEvent* output)
 	// TODO: should this just change to a getter?
 	if (!fstate.polledMouseMovement)
 	{
+		output->eventType = FOSTER_EVENT_TYPE_MOUSE_MOVE;
+
 		int mouseX, mouseY;
 		SDL_GetMouseState(&mouseX, &mouseY);
-		output->eventType = FOSTER_EVENT_TYPE_MOUSE_MOVE;
 		output->mouse.x = (float)mouseX;
 		output->mouse.y = (float)mouseY;
+
+		SDL_GetRelativeMouseState(&mouseX, &mouseY);
+		output->mouse.deltaX = (float)mouseX;
+		output->mouse.deltaY = (float)mouseY;
+
 		fstate.polledMouseMovement = 1;
 		return 1;
 	}


### PR DESCRIPTION
Feel free to kick this PR into a lake if it's not considered useful (or if you're already doing this somewhere and I didn't catch that). I think its useful that SDL already provides this as part of it's input subsystem, so this PR exposes includes the relative mouse position as part of the input state.