### PR TITLE
include xml documentation

### DIFF
--- a/Framework/Foster.Framework.csproj
+++ b/Framework/Foster.Framework.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Title>Foster</Title>
     <Product>Foster</Product>
-    <Version>0.1.18-alpha</Version>
+    <Version>0.1.19-alpha</Version>
     <Authors>Noel Berry</Authors>
     <Description>A small 2D cross-platform Game Framework</Description>
     <RepositoryType>git</RepositoryType>
@@ -19,6 +19,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>$(SolutionDir)artifacts/</PackageOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
this is to allow xml documentation to be viewed from the nupkg and possibly displayed from a static site like https://dotnet.github.io/docfx/