### PR TITLE
Started multisampling implementation

### DIFF
--- a/Framework/Graphics/Defaults/BatcherShader.cs
+++ b/Framework/Graphics/Defaults/BatcherShader.cs
@@ -16,7 +16,7 @@ public class BatcherShader(GraphicsDevice graphicsDevice)
 		),
 		Fragment: new(
 			Code: Platform.ReadEmbeddedBytes($"Batcher.fragment.{graphicsDevice.Driver.GetShaderExtension()}"),
-			SamplerCount: graphicsDevice.SamplerCount,
+			SamplerCount: 1,
 			UniformBufferCount: 0,
 			EntryPoint: "fragment_main"
 		)

--- a/Framework/Graphics/Defaults/BatcherShader.cs
+++ b/Framework/Graphics/Defaults/BatcherShader.cs
@@ -16,7 +16,7 @@ public class BatcherShader(GraphicsDevice graphicsDevice)
 		),
 		Fragment: new(
 			Code: Platform.ReadEmbeddedBytes($"Batcher.fragment.{graphicsDevice.Driver.GetShaderExtension()}"),
-			SamplerCount: 1,
+			SamplerCount: graphicsDevice.SamplerCount,
 			UniformBufferCount: 0,
 			EntryPoint: "fragment_main"
 		)

--- a/Framework/Graphics/Defaults/TexturedShader.cs
+++ b/Framework/Graphics/Defaults/TexturedShader.cs
@@ -16,7 +16,7 @@ public class TexturedShader(GraphicsDevice graphicsDevice)
 		),
 		Fragment: new(
 			Code: Platform.ReadEmbeddedBytes($"Textured.fragment.{graphicsDevice.Driver.GetShaderExtension()}"),
-			SamplerCount: 1,
+			SamplerCount: graphicsDevice.SamplerCount,
 			UniformBufferCount: 0,
 			EntryPoint: "fragment_main"
 		)

--- a/Framework/Graphics/Defaults/TexturedShader.cs
+++ b/Framework/Graphics/Defaults/TexturedShader.cs
@@ -16,7 +16,7 @@ public class TexturedShader(GraphicsDevice graphicsDevice)
 		),
 		Fragment: new(
 			Code: Platform.ReadEmbeddedBytes($"Textured.fragment.{graphicsDevice.Driver.GetShaderExtension()}"),
-			SamplerCount: graphicsDevice.SamplerCount,
+			SamplerCount: 1,
 			UniformBufferCount: 0,
 			EntryPoint: "fragment_main"
 		)

--- a/Framework/Graphics/GraphicsDevice.cs
+++ b/Framework/Graphics/GraphicsDevice.cs
@@ -38,6 +38,11 @@ public abstract class GraphicsDevice
 	/// </summary>
 	public abstract bool VSync { get; set; }
 
+	/// <summary>
+	/// Sampler count used for multisampling
+	/// </summary>
+	public abstract int SamplerCount { get; set; }
+
 	internal GraphicsDevice(App app) => App = app;
 	internal abstract void CreateDevice(in AppFlags flags);
 	internal abstract void DestroyDevice();
@@ -92,13 +97,13 @@ public abstract class GraphicsDevice
 			return;
 		}
 
-		if (command.Viewport is {} viewport && (viewport.Width <= 0 || viewport.Height <= 0))
+		if (command.Viewport is { } viewport && (viewport.Width <= 0 || viewport.Height <= 0))
 		{
 			Log.Warning("Attempting to render with an empty Viewport");
 			return;
 		}
 
-		if (command.Scissor is {} scissor && (scissor.Width <= 0 || scissor.Height <= 0))
+		if (command.Scissor is { } scissor && (scissor.Width <= 0 || scissor.Height <= 0))
 		{
 			Log.Warning("Attempting to render with an empty Scissor");
 			return;


### PR DESCRIPTION
_**NOT INTENDED TO BE PULLED FOR NOW**_

I'm publishing this pull request as a purpose. As I mentionned in the discord server, I'm giving few tries on this topic and I'm trying to implement kind of a multisampling feature inside Foster.
So we can discuss here about the code I wrote and improve everything.

I added a SampleCount on the `GraphicsDevice` as an int and converted on the right enum value inside the `GraphicsDeviceSDL`.
Then I remplaced current usage of the `SDL_GPUSampleCount` with that new property.

It should then be possible to use the multisampling inside any app by doing:
```cs
// possible values: 0, 2, 4, 8
GraphicsDevice.SampleCount = 2
```
By running the app using this value of sample count, the app start with a black screen and the following console log warning from the line: https://github.com/akaadream/Foster/blob/33a8e712c0fa90e8bdac01acaf3c95d35a241917/Framework/Internal/GraphicsDeviceSDL.cs#L371
This means there is something wrong with this implementation and my knowledges are not good enough to understand what is wrong.

I put here the documentation I used when I tried to implement it:
* https://wiki.libsdl.org/SDL3/SDL_GPUSampleCount
* https://wiki.libsdl.org/SDL3/SDL_GPUTextureCreateInfo
* https://wiki.libsdl.org/SDL3/SDL_GPUMultisampleState
* https://vulkan-tutorial.com/Multisampling

If you have ideas or knowledges to share, I take them with pleasure. 