### PR TITLE
Initialize the window resizable flag with the initial value (provided in `AppConfig`)

### DIFF
--- a/Framework/App.cs
+++ b/Framework/App.cs
@@ -196,7 +196,7 @@ public abstract class App : IDisposable
 		FileSystem = new(this);
 		GraphicsDevice = Platform.CreateGraphicsDevice(this, config.PreferredGraphicsDriver);
 		GraphicsDevice.CreateDevice(config.Flags);
-		Window = new Window(this, GraphicsDevice, config.WindowTitle, config.Width, config.Height, config.Fullscreen);
+		Window = new Window(this, GraphicsDevice, config.WindowTitle, config.Width, config.Height, config.Fullscreen, config.Resizable);
 		GraphicsDevice.Startup(Window.Handle);
 
 		// try to load default SDL gamepad mappings

--- a/Framework/Window.cs
+++ b/Framework/Window.cs
@@ -273,18 +273,20 @@ public sealed class Window : IDrawableTarget
 	/// </summary>
 	public Action? OnCloseRequested;
 
-	internal Window(App app, GraphicsDevice graphicsDevice, string title, int width, int height, bool fullscreen)
+	internal Window(App app, GraphicsDevice graphicsDevice, string title, int width, int height, bool fullscreen, bool resizable)
 	{
 		this.app = app;
 		this.graphicsDevice = graphicsDevice;
 		this.title = title;
 
 		var windowFlags = 
-			SDL_WindowFlags.SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WindowFlags.SDL_WINDOW_RESIZABLE | 
+			SDL_WindowFlags.SDL_WINDOW_HIGH_PIXEL_DENSITY |
 			SDL_WindowFlags.SDL_WINDOW_HIDDEN;
 
 		if (fullscreen)
 			windowFlags |= SDL_WindowFlags.SDL_WINDOW_FULLSCREEN;
+		if (resizable)
+			windowFlags |= SDL_WindowFlags.SDL_WINDOW_RESIZABLE;
 
 		Handle = SDL_CreateWindow(title, width, height, windowFlags);
 		if (Handle == IntPtr.Zero)


### PR DESCRIPTION
`AppConfig.Resizable` was not being passed into `Window.ctor`, so the application's window would be resizable even if you disabled it.