### PR TITLE
build ARM32 and ARM64 Linux Native Binaries for SDL3

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-latest
             target: linux-x64
             lib: libSDL3.so
+          - os: ubuntu-22.04-arm
+            target: linux-arm64
+            lib: libSDL3.so
     runs-on: ${{matrix.os}}
     steps:
       - name: Clone SDL3

--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -23,8 +23,20 @@ jobs:
           - os: ubuntu-22.04-arm
             target: linux-arm64
             lib: libSDL3.so
+          - os: ubuntu-22.04-arm
+            target: linux-arm
+            lib: libSDL3.so
+            container: arm32v7/ubuntu:jammy
     runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
     steps:
+      - name: Setup ARM32 Container Pre-Depends
+        if: ${{ matrix.target == 'linux-arm' }}
+        run: |
+          # add arm64 architecture for arm64 nodeJS for actions/upload-artifact inherited from the host
+          dpkg --add-architecture arm64
+          apt-get update
+          apt-get install -y sudo git libc6:arm64 libstdc++6:arm64
       - name: Clone SDL3
         run: git clone --depth 1 --branch ${{env.SDL_VERSION}} https://github.com/libsdl-org/sdl sdl3-src
       - name: Setup macOS universal build
@@ -34,7 +46,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential git make \
+          sudo apt-get install -y build-essential git make \
             pkg-config cmake ninja-build gnome-desktop-testing libasound2-dev libpulse-dev \
             libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
             libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \

--- a/Framework/Foster.Framework.csproj
+++ b/Framework/Foster.Framework.csproj
@@ -42,6 +42,12 @@
       <Pack>True</Pack>
       <Link>%(Filename)%(Extension)</Link>
     </Content>
+    <Content Include="$(NativeLibsDir)linux-arm64\**" Visible="false">
+      <CopyToOutputDirectory Condition="('$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOSPlatform('Linux'))) or '$(RuntimeIdentifier)' == 'linux-arm64'">PreserveNewest</CopyToOutputDirectory>
+      <PackagePath>runtimes\linux-arm64\native</PackagePath>
+      <Pack>True</Pack>
+      <Link>%(Filename)%(Extension)</Link>
+    </Content>
     <Content Include="$(NativeLibsDir)osx\**" Visible="false">
       <CopyToOutputDirectory Condition="('$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOSPlatform('OSX'))) or '$(RuntimeIdentifier)' == 'osx-x64'">PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\osx\native</PackagePath>

--- a/Framework/Foster.Framework.csproj
+++ b/Framework/Foster.Framework.csproj
@@ -48,6 +48,12 @@
       <Pack>True</Pack>
       <Link>%(Filename)%(Extension)</Link>
     </Content>
+    <Content Include="$(NativeLibsDir)linux-arm\**" Visible="false">
+      <CopyToOutputDirectory Condition="('$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOSPlatform('Linux'))) or '$(RuntimeIdentifier)' == 'linux-arm'">PreserveNewest</CopyToOutputDirectory>
+      <PackagePath>runtimes\linux-arm\native</PackagePath>
+      <Pack>True</Pack>
+      <Link>%(Filename)%(Extension)</Link>
+    </Content>
     <Content Include="$(NativeLibsDir)osx\**" Visible="false">
       <CopyToOutputDirectory Condition="('$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOSPlatform('OSX'))) or '$(RuntimeIdentifier)' == 'osx-x64'">PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\osx\native</PackagePath>


### PR DESCRIPTION
This builds and places the binaries successfully. I believe the paths are right for applications to pull these in when including Foster.

I have tested the ARM64 linux binary and confirm there are no issues with it with my build of Celeste 64 https://github.com/theofficialgman/Celeste64/releases/tag/test5

progress towards: https://github.com/EXOK/Celeste64/issues/105